### PR TITLE
Remove adding action as string

### DIFF
--- a/action.md
+++ b/action.md
@@ -73,8 +73,6 @@ function callback()
     // Code...
 }
 
-Action::add('init', 'callback');
-
 // Using a closure
 Action::add('init', function()
 {


### PR DESCRIPTION
```php
function callback()
{
    // Code...
}

Action::add('init', 'callback');
```
This syntax is invalid, it looks for a class not a function.

It caused the confusion here:  https://github.com/themosis/themosis/issues/88