### PR TITLE
Update gettext instructions for Poedit 2

### DIFF
--- a/twig.md
+++ b/twig.md
@@ -345,10 +345,18 @@ Here is an example on how to call these functions within your Twig view:
 </html>
 ```
 
-Poedit
-------
+Extracting strings with Poedit
+------------------------------
 
-By default, Poedit cannot find strings to translate from Twig templates. Here is a list of parameters to add to your Poedit software preferences so it can detect translation strings from your Twig views:
+### Using Poedit 2
+
+Poedit 2 has native support for extracting from Twig files and no extra setup is necessary (Pro version).
+
+### Using Poedit 1.x
+
+(Also usable in Poedit 2.) By default, Poedit cannot find strings to translate from Twig templates. It's possible to workaround this by pretending to Poedit that Twig files are written in Python. This may produce some warnings, but mostly works. Note however that this method may miss some strings; quotes in particular (such as in HTML attributes) can cause it to skip over `__` calls.
+
+Here is a list of parameters to add to your Poedit software preferences so it can detect translation strings from your Twig views:
 
 1. Open Poedit
 2. Go to Preferences -> Parsers


### PR DESCRIPTION
This PR updates documentation on extracting `__` etc. strings to warn about the inability to extract from quoted strings when relying on the workaround hack with pretending that the template is a PHP 
or Python source file.

Also adds an explanation that the workaround to make Poedit extract strings by pretending that Twig files are Python ones has some limitations: in particular, pretty much any use of quotes prevents extraction from within them. Plenty of people are understandably surprised by this behavior (exhibit [A](https://stackoverflow.com/questions/34243278/poedit-doesnt-extract-string-in-html-tags), [B](https://stackoverflow.com/questions/33910482/xgettext-does-not-extract-string-in-html-attribute), [C](https://stackoverflow.com/questions/38665666/how-to-parse-timber-twig-templates-with-poedit-and-detect-quoted-strings-to-tr) to show a few public ones on SO), so being upfront about it hopefully prevents a few nasty surprises.

*(I'm basing this off 1.3, but am not sure if it's correct. If you'd like me to rebase against `master`, or submit PRs for both, just tell me.)*