### PR TITLE
Remove Blade 'or' operator, Add PHP null coalesce

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -143,10 +143,10 @@ By default you could write the following statement:
 ```html
 {{ isset($name) ? $name : 'Default' }}
 ```
-Instead of writing a ternary statement, Blade allows you to use the following convenient short-cut:
+Instead of writing a ternary statement, Blade allows you to use PHP's built in `??` "null coalesce" operator:
 
 ```html
-{{ $name or 'Default' }}
+{{ $name ?? 'Default' }}
 ```
 
 ### Conditional statements


### PR DESCRIPTION
As of `illuminate/view 5.7.x`, Blade's `or` operator has been removed in favour of PHP's built-in `??` "null coalesce" operator.