### PR TITLE
Feature/or-replacement

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -174,7 +174,7 @@ By default you could write the following statement:
 Instead of writing a ternary statement, Blade allows you to use the following convenient short-cut:
 
 ```html
-{{ $name or 'Default' }}
+{{ $name ?? 'Default' }}
 ```
 
 ### Conditional statements


### PR DESCRIPTION
```php
or has been removed from Blade in favour
of the new PHP null coalescing operator.
```
@arjendejong12 got confused when copying code and he got an error from the `or` operator. 